### PR TITLE
URL Cleanup

### DIFF
--- a/LICENSE.writing.txt
+++ b/LICENSE.writing.txt
@@ -1,1 +1,1 @@
-Except where otherwise noted, this work is licensed under http://creativecommons.org/licenses/by-nd/3.0/
+Except where otherwise noted, this work is licensed under https://creativecommons.org/licenses/by-nd/3.0/

--- a/README.adoc
+++ b/README.adoc
@@ -1,15 +1,15 @@
 :spring_version: current
 :spring_boot_version: 2.1.3.RELEASE
-:SpringData: http://projects.spring.io/spring-data/
-:Cacheable: http://docs.spring.io/spring/docs/current/javadoc-api/org/springframework/cache/annotation/Cacheable.html
-:CachePut: http://docs.spring.io/spring/docs/current/javadoc-api/org/springframework/cache/annotation/CachePut.html
-:CacheEvict: http://docs.spring.io/spring/docs/current/javadoc-api/org/springframework/cache/annotation/CacheEvict.html
-:CachingConfigurer: http://docs.spring.io/spring/docs/{spring_version}/javadoc-api/org/springframework/cache/annotation/CachingConfigurer.html
-:EnableCaching: http://docs.spring.io/spring/docs/{spring_version}/javadoc-api/org/springframework/cache/annotation/EnableCaching.html
-:CacheManager: http://docs.spring.io/spring/docs/{spring_version}/javadoc-api/org/springframework/cache/CacheManager.html
-:documentation: http://docs.spring.io/spring/docs/current/spring-framework-reference/html/cache.html
+:SpringData: https://projects.spring.io/spring-data/
+:Cacheable: https://docs.spring.io/spring/docs/current/javadoc-api/org/springframework/cache/annotation/Cacheable.html
+:CachePut: https://docs.spring.io/spring/docs/current/javadoc-api/org/springframework/cache/annotation/CachePut.html
+:CacheEvict: https://docs.spring.io/spring/docs/current/javadoc-api/org/springframework/cache/annotation/CacheEvict.html
+:CachingConfigurer: https://docs.spring.io/spring/docs/{spring_version}/javadoc-api/org/springframework/cache/annotation/CachingConfigurer.html
+:EnableCaching: https://docs.spring.io/spring/docs/{spring_version}/javadoc-api/org/springframework/cache/annotation/EnableCaching.html
+:CacheManager: https://docs.spring.io/spring/docs/{spring_version}/javadoc-api/org/springframework/cache/CacheManager.html
+:documentation: https://docs.spring.io/spring/docs/current/spring-framework-reference/html/cache.html
 :bootcaching: https://docs.spring.io/spring-boot/docs/current/reference/html/boot-features-caching.html
-:runner: http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#boot-features-command-line-runner
+:runner: https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#boot-features-command-line-runner
 :toc:
 :icons: font
 :source-highlighter: prettify


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://creativecommons.org/licenses/by-nd/3.0/ with 1 occurrences migrated to:  
  https://creativecommons.org/licenses/by-nd/3.0/ ([https](https://creativecommons.org/licenses/by-nd/3.0/) result 200).
* [ ] http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/ with 1 occurrences migrated to:  
  https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/ ([https](https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/) result 200).
* [ ] http://docs.spring.io/spring/docs/ with 3 occurrences migrated to:  
  https://docs.spring.io/spring/docs/ ([https](https://docs.spring.io/spring/docs/) result 200).
* [ ] http://projects.spring.io/spring-data/ with 1 occurrences migrated to:  
  https://projects.spring.io/spring-data/ ([https](https://projects.spring.io/spring-data/) result 200).
* [ ] http://docs.spring.io/spring/docs/current/javadoc-api/org/springframework/cache/annotation/CacheEvict.html with 1 occurrences migrated to:  
  https://docs.spring.io/spring/docs/current/javadoc-api/org/springframework/cache/annotation/CacheEvict.html ([https](https://docs.spring.io/spring/docs/current/javadoc-api/org/springframework/cache/annotation/CacheEvict.html) result 301).
* [ ] http://docs.spring.io/spring/docs/current/javadoc-api/org/springframework/cache/annotation/CachePut.html with 1 occurrences migrated to:  
  https://docs.spring.io/spring/docs/current/javadoc-api/org/springframework/cache/annotation/CachePut.html ([https](https://docs.spring.io/spring/docs/current/javadoc-api/org/springframework/cache/annotation/CachePut.html) result 301).
* [ ] http://docs.spring.io/spring/docs/current/javadoc-api/org/springframework/cache/annotation/Cacheable.html with 1 occurrences migrated to:  
  https://docs.spring.io/spring/docs/current/javadoc-api/org/springframework/cache/annotation/Cacheable.html ([https](https://docs.spring.io/spring/docs/current/javadoc-api/org/springframework/cache/annotation/Cacheable.html) result 301).
* [ ] http://docs.spring.io/spring/docs/current/spring-framework-reference/html/cache.html with 1 occurrences migrated to:  
  https://docs.spring.io/spring/docs/current/spring-framework-reference/html/cache.html ([https](https://docs.spring.io/spring/docs/current/spring-framework-reference/html/cache.html) result 301).